### PR TITLE
Suggestion: Static Cache

### DIFF
--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -3,7 +3,15 @@ import {Container} from "./container";
 function inject(type: symbol, container: Container) {
     return function(target: object, property: string): void {
         Object.defineProperty(target, property, {
-            get: () => container.get<any>(type),
+            get: function() {
+                const value = container.get<any>(type);
+                Object.defineProperty(this, property, {
+                    value,
+                    enumerable: true,
+                });
+                return value;
+            },
+            configurable: true,
             enumerable: true,
         });
     };


### PR DESCRIPTION
This is a suggestion of a configurable cache. It is made with extensibility in mind (Tags).

Without caching a dependency, configured without the `.inSingeltonScope()` option, will resolve new data on every get on the property. With caching it will only resolved once per instance.

```ts
container.bind<IMyService>(TYPE.MyService).to(MyService);

class Something {

    @inject(Type.MyService)
    private service!: IMyService;

}
```
In this example calling `this.service` will resolve only once. In the current behavior this will resolve a new instance every time `this.service` is called.

This solution is not configurable. This behavior cannot changed. The alternative is the [configurable cache](https://github.com/owja/ioc/pull/17) implementation.

### Bundle Sizes
* Configurable: 704 Byte
* Static: 625 Byte
* Current: 601 Byte

### Question

 *Which implementation whould you prefer? Or keep the current state? Or any other suggestion?*

### Links
[Issue: Cache None-Singletons](https://github.com/owja/ioc/issues/18)
[Suggestion: Configurable Cache](https://github.com/owja/ioc/pull/17)