### PR TITLE
Suggestion: Configurable Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,141 @@ It is currently work in progress and in unstable beta phase
 but the API should not change anymore before 1.0.0 stable release
 will arrived.
 
-### Usage
+## The Container API
 
-##### Step 1 - Installing the OWJA! IoC library
+### Creating a container
+
+The container is the place where all dependencies get bound to. We can have
+multiple containers in our project in parallel.
+
+```ts
+import {Container} from "@owja/ioc";
+const container = new Container();
+```
+
+### Binding
+
+#### Binding a class
+
+This is the default way to bind a dependency. The class will get instantiated when the
+dependency gets resolved.
+
+```ts
+container.bind<ServiceInterface>(symbol).to(Service);
+```
+
+#### Binding a class in singleton scope
+
+This will create only one instance of `Service`
+
+```ts
+container.bind<ServiceInterface>(symbol).to(Service).inSingletonScope();
+```
+
+#### Binding a factory
+
+Factories are functions which will get called when the dependency gets resolved 
+
+```ts
+container.bind<ServiceInterface>(symbol).toFactory(() => new Service());
+container.bind<string>(symbol).toFactory(() => "just a string");
+```
+
+A factory can configured for singleton scope too. This way will only executed once.
+
+```ts
+container.bind<ServiceInterface>(symbol).toFactory(() => new Service()).inSingletonScope();
+```
+
+#### Binding a value
+
+This is always like singleton scope, but it should be avoid to instantiate
+dependencies here. If they are circular dependencies, they will fail. 
+
+```ts
+container.bind<ServiceInterface>(symbol).toValue(new Service());
+container.bind<string>(symbol).toValue("just a string");
+container.bind<() => string>(symbol).toValue(() => "i am a function");
+```
+
+### Rebinding
+
+This is the way how we can rebind a dependency while **unit tests**. We should not need to
+rebind in production code.
+
+```ts
+container.rebind<ServiceMock>(symbol).toValue(new ServiceMock());
+```
+
+### Removing
+
+Normally this function is not used in production code. This will remove the
+dependency from the container. 
+
+```ts
+container.remove(symbol);
+```
+
+### Getting a dependency
+
+Getting dependencies without `inject` decorators are only meant for **unit tests**. This is also
+the internal way the `inject` decorator gets the dependency it has to resolve.
+ 
+```ts
+container.get<Interface>(symbol);
+```
+
+### Snapshot & Restore
+
+This creates a snapshot of the bound dependencies. After this we can rebind dependencies
+and can restore it back to its old state after we made some **unit tests**.
+
+```ts
+container.snapshot();
+```
+```ts
+container.restore();
+```
+
+## The `inject` Decorator
+
+We have to create a `inject` decorator for each container.
+
+```ts
+import {createDecorator} from "@owja/ioc";
+
+export const inject = createDecorator(container);
+```
+
+This decorator is needed to resolve our dependencies. 
+
+```ts
+class Example {
+    @inject(symbol)
+    readonly service!: Interface;
+}
+```
+
+## The `symbol`
+
+Symbols are used to identify our dependencies. A good practice is to keep them in one place.
+
+```ts
+export const TYPE = {
+    "Service" = Symbol.for("Service"),
+    // [...]
+}
+```
+
+## Usage
+
+#### Step 1 - Installing the OWJA! IoC library
 
 ```bash
 npm install --save-dev @owja/ioc
 ``` 
 
-##### Step 2 - Create symbols for our dependencies
+#### Step 2 - Create symbols for our dependencies
 
 Now we create the folder ***services*** and add the new file ***services/types.ts***:
 ```ts
@@ -30,7 +156,7 @@ export const TYPE = {
 };
 ```
 
-##### Step 3 - Creating a container
+#### Step 3 - Creating a container
 
 Next we need a container to bind our dependencies to. Let's create the file ***services/container.ts***
 
@@ -51,7 +177,7 @@ container.bind<IMyOtherService>(TYPE.MyOtherService).to(MyOtherService);
 export {container, TYPE, inject};
 ```
 
-##### Step 4 - Injecting dependencies
+#### Step 4 - Injecting dependencies
 
 Lets create a ***example.ts*** file in our source root:
  
@@ -76,12 +202,35 @@ console.log(example.myOtherSerice);
 
 If we run this example we should see the content of our example services.
 
-### Unit testing with IoC
+The dependencies (services) will injected on the first call. This means if you rebind the service after
+accessing the properties of the Example class, it will not resolve the new service. If you want a new 
+service each time you call `example.myService` you have to add the `NOCACHE` tag:
+
+```ts
+import {container, TYPE, inject} from "./services/container";
+import {NOCACHE} from "@owja/ioc";
+
+// [...]
+
+class Example {
+    @inject(TYPE.MyService, NOCACHE)
+    readonly myService!: IMyService;
+    
+    @inject(TYPE.MyOtherSerice, NOCACHE)
+    readonly myOtherService!: IMyOtherService;
+}
+
+// [...]
+```
+
+## Unit testing with IoC
 
 We can snapshot and restore a container for unit testing.
 We are able to make multiple snapshots in a row too.
 
 ```ts
+import {container, TYPE} from "./services/container";
+
 beforeEach(() => {
     container.snapshot();
 });
@@ -96,12 +245,12 @@ test("can do something", () => {
 });
 ```
 
-### Development
+## Development
 
 We are working on the first stable release. Current state of development can be seen in our
 [Github Project](https://github.com/owja/ioc/projects/1) for the first release.
 
-### Inspiration
+## Inspiration
 
 This library is highly inspired by [InversifyJS](https://github.com/inversify/InversifyJS)
 but has other goals:
@@ -111,7 +260,7 @@ but has other goals:
 3. Always lazy inject the dependencies
 4. No meta-reflect required
 
-### License
+## License
 
 License under [Creative Commons Attribution 4.0 International](https://spdx.org/licenses/CC-BY-4.0.html)
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
     "type": "git",
     "url": "git+https://github.com/owja/ioc.git"
   },
+  "bugs": {
+    "url": "https://github.com/owja/ioc/issues"
+  },
+  "homepage": "https://github.com/owja/ioc",
   "author": "Hauke Broer <info@owja.de>",
   "license": "CC-BY-4.0",
-  "homepage": "https://github.com/owja/ioc",
   "devDependencies": {
     "@types/jest": "^24.0.13",
     "@typescript-eslint/eslint-plugin": "^1.9.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,13 +1,17 @@
-import {Container, createDecorator} from "./";
+import {Container, createDecorator, NOCACHE} from "./";
 import {Container as ContainerOriginal} from "./ioc/container";
-import {createDecorator as createDecoratorOriginal} from "./ioc/inject";
+import {createDecorator as createDecoratorOriginal, NOCACHE as NOCACHEOriginal} from "./ioc/inject";
 
 describe("Module", () => {
     test('should export "Container" class', () => {
-        expect(Container).toEqual(ContainerOriginal);
+        expect(Container).toBe(ContainerOriginal);
     });
 
     test('should export "createDecorator" function', () => {
-        expect(createDecorator).toEqual(createDecoratorOriginal);
+        expect(createDecorator).toBe(createDecoratorOriginal);
+    });
+
+    test('should export "NOCACHE" symbol/tag', () => {
+        expect(NOCACHE).toBe(NOCACHEOriginal);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export {Container} from "./ioc/container";
-export {createDecorator} from "./ioc/inject";
+export {createDecorator, NOCACHE} from "./ioc/inject";

--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -1,5 +1,5 @@
 import {Container} from "./container";
-import {createDecorator} from "./inject";
+import {createDecorator, NOCACHE} from "./inject";
 
 const container = new Container();
 const inject = createDecorator(container);
@@ -26,6 +26,7 @@ const TYPE = {
     circular2: Symbol.for("circular2"),
     circularFail1: Symbol.for("circularFail1"),
     circularFail2: Symbol.for("circularFail2"),
+    cacheTest: Symbol.for("cacheTest"),
 };
 
 class Parent implements ITestClass {
@@ -98,6 +99,13 @@ class CircularFail2 implements ICircular {
     }
 }
 
+class CacheTest {
+    @inject(TYPE.cacheTest)
+    cached!: number;
+    @inject(TYPE.cacheTest, NOCACHE)
+    notCached!: number;
+}
+
 container.bind<ITestClass>(TYPE.parent).to(Parent);
 container.bind<ITestClass>(TYPE.child1).to(ChildOne);
 container.bind<ITestClass>(TYPE.child2).to(ChildTwo);
@@ -107,6 +115,9 @@ container.bind<ICircular>(TYPE.circularFail1).toFactory(() => new CircularFail1(
 container.bind<ICircular>(TYPE.circularFail2).toFactory(() => new CircularFail2("two"));
 container.bind<ICircular>(TYPE.circular1).toFactory(() => new Circular1("one"));
 container.bind<ICircular>(TYPE.circular2).toFactory(() => new Circular2("two"));
+
+let count: number;
+container.bind<number>(TYPE.cacheTest).toFactory(() => ++count);
 
 describe("Injector", () => {
     let instance: Parent;
@@ -141,5 +152,49 @@ describe("Injector", () => {
 
     test("can not inject a circular dependency when accessing the dependency inside of constructor", () => {
         expect(() => container.get<ICircular>(TYPE.circularFail1)).toThrow("Maximum call stack size exceeded");
+    });
+
+    test("resolves only once with cache enabled by default", () => {
+        count = 0;
+        const cacheTest = new CacheTest();
+        expect(cacheTest.cached).toBe(1);
+        expect(cacheTest.cached).toBe(1);
+        expect(cacheTest.cached).toBe(1);
+    });
+
+    test("resolves new data each request without cache enabled", () => {
+        count = 0;
+        const cacheTest = new CacheTest();
+        expect(cacheTest.notCached).toBe(1);
+        expect(cacheTest.notCached).toBe(2);
+        expect(cacheTest.notCached).toBe(3);
+    });
+
+    test("resolves new data with new instance even with cache enabled", () => {
+        count = 0;
+        const cacheTest1 = new CacheTest();
+        expect(cacheTest1.cached).toBe(1);
+        expect(cacheTest1.cached).toBe(1);
+
+        count = 9;
+        const cacheTest2 = new CacheTest();
+        expect(cacheTest2.cached).toBe(10);
+        expect(cacheTest2.cached).toBe(10);
+
+        // final proof
+        expect(cacheTest1.cached).toBe(1);
+    });
+
+    test("resolves new data with new instance even with cache disabled", () => {
+        count = 0;
+        const cacheTest1 = new CacheTest();
+        const cacheTest2 = new CacheTest();
+        expect(cacheTest1.notCached).toBe(1);
+        expect(cacheTest1.notCached).toBe(2);
+        expect(cacheTest2.notCached).toBe(3);
+        expect(cacheTest2.notCached).toBe(4);
+
+        // final proof
+        expect(cacheTest1.notCached).toBe(5);
     });
 });

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -1,16 +1,28 @@
 import {Container} from "./container";
 
-function inject(type: symbol, container: Container) {
+export const NOCACHE = Symbol.for("NOCACHE");
+
+function inject(type: symbol, container: Container, args?: symbol[]) {
     return function(target: object, property: string): void {
         Object.defineProperty(target, property, {
-            get: () => container.get<any>(type),
+            get: function() {
+                const value = container.get<any>(type);
+                if (args && args.indexOf(NOCACHE)) {
+                    Object.defineProperty(this, property, {
+                        value,
+                        enumerable: true,
+                    });
+                }
+                return value;
+            },
+            configurable: true,
             enumerable: true,
         });
     };
 }
 
 export function createDecorator(container: Container) {
-    return function(type: symbol) {
-        return inject(type, container);
+    return function(type: symbol, ...args: symbol[]) {
+        return inject(type, container, args);
     };
 }


### PR DESCRIPTION
This is a suggestion of a configurable cache. It is made with extensibility in mind (Tags).

Without caching a dependency, configured without the `.inSingeltonScope()` option, will resolve new data on every get of the property. With caching it will only resolved once per instance.

```ts
container.bind<IMyService>(TYPE.MyService).to(MyService);

class Something {

    @inject(Type.MyService, NOCACHE)
    private notCached!: IMyService;

    @inject(Type.MyService)
    private cached!: IMyService;

}
```
In this example getting `this.notCached` will create each call a new instance of `MyService` which is the current behavior. On the contrary, calling `this.cached` will resolve only once.

The alternative of the configurable cache, a [static cache](https://github.com/owja/ioc/pull/16).

### Bundle Sizes
* Configurable: 704 Byte
* Static: 625 Byte
* Current: 601 Byte

### Question

 *Which implementation whould you prefer? Or keep the current state? Or any other suggestion?*

### Links
[Issue: Cache None-Singletons](https://github.com/owja/ioc/issues/18)
[Suggestion: Static Cache](https://github.com/owja/ioc/pull/16)