### PR TITLE
Injection without decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ class Example {
 
 ## The `resolve()` Function
 
-A second way to resolve a dependency is to use `resolve()`. We have to create the
-function first like before.
+A second way to resolve a dependency without decorators is to use `resolve()`.
+To use `resolve()` we have to create the function first.
 
 ```ts
 import {createResolve} from "@owja/ioc";
@@ -208,7 +208,7 @@ function Example() {
 > The dependency is not assigned directly to the property/constant.
 > If we want direct access we can use `container.get()` but we should avoid
 > using `get()` inside of classes because we then loose the lazy dependency
-> resolving behavior. 
+> resolving/injection behavior. 
 
 ## The `symbol`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ will arrive.
 ## Features
 
 * Similar syntax to InversifyJS
+* Can be used without decorators
 * Less Features but **straight forward**
 * Can bind dependencies as **classes**, **factories** and **static values**
 * Supports binding in **singleton scope**
@@ -23,7 +24,6 @@ will arrive.
 * Supports dependency **rebinding** and container **snapshots** and **restores**
 * **Lightweight** - Just around **750 Byte gzip** and **650 Byte brotli** compressed
 * Does **NOT** need reflect-metadata which size is around 50 kb
-* Can be used without inject decorator
 * 100% written in **Typescript**
 
 ## The Container API

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ Then we can wire up the dependent to the dependency.
 
 ```ts
 class Example {
-    readonly service!: IMyService;
+    readonly service!: Interface;
+    
     constructor() {
-        wire(this, "service", TYPE.MyService);
+        wire(this, "service", symbol);
     }
     
     method() {
@@ -188,7 +189,7 @@ Then we can resolve the dependency in classes and even functions.
 
 ```ts
 class Example {
-    readonly service = resolve<IMyService>(TYPE.MyService)
+    readonly service = resolve<Interface>(symbol)
     
     method() {
         this.service().doSomething();
@@ -198,7 +199,7 @@ class Example {
 
 ```ts
 function Example() {
-    const service = resolve<IMyService>(TYPE.MyService)
+    const service = resolve<Interface>(symbol)
     service().doSomething();
 }
 ```
@@ -261,14 +262,14 @@ import {Container, createDecorator} from "@owja/ioc";
 
 import {TYPE} from "./types";
 
-import {IMyService, MyService} from "./service/my-service";
-import {IMyOtherService, MyOtherService} from "./service/my-other-service";
+import {MyServiceInterface, MyService} from "./service/my-service";
+import {MyOtherServiceInterface, MyOtherService} from "./service/my-other-service";
 
 const container = new Container();
 const inject = createDecorator(container);
 
-container.bind<IMyService>(TYPE.MyService).to(MyService);
-container.bind<IMyOtherService>(TYPE.MyOtherService).to(MyOtherService);
+container.bind<MyServiceInterface>(TYPE.MyService).to(MyService);
+container.bind<MyOtherServiceInterface>(TYPE.MyOtherService).to(MyOtherService);
 
 export {container, TYPE, inject};
 ```
@@ -279,15 +280,15 @@ Lets create a ***example.ts*** file in our source root:
  
 ```ts
 import {container, TYPE, inject} from "./services/container";
-import {IMyService} from "./service/my-service";
-import {IMyOtherService} from "./service/my-other-service";
+import {MyServiceInterface} from "./service/my-service";
+import {MyOtherServiceInterface} from "./service/my-other-service";
 
 class Example {
     @inject(TYPE.MyService)
-    readonly myService!: IMyService;
+    readonly myService!: MyServiceInterface;
     
     @inject(TYPE.MyOtherSerice)
-    readonly myOtherService!: IMyOtherService;
+    readonly myOtherService!: MyOtherServiceInterface;
 }
 
 const example = new Example();
@@ -310,10 +311,10 @@ import {NOCACHE} from "@owja/ioc";
 
 class Example {
     @inject(TYPE.MyService, NOCACHE)
-    readonly myService!: IMyService;
+    readonly myService!: MyServiceInterface;
     
     @inject(TYPE.MyOtherSerice, NOCACHE)
-    readonly myOtherService!: IMyOtherService;
+    readonly myOtherService!: MyOtherServiceInterface;
 }
 
 // [...]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,11 @@
-import {Container, createDecorator, NOCACHE} from "./";
+import {Container, createDecorator, createResolve, createWire, NOCACHE} from "./";
 import {Container as ContainerOriginal} from "./ioc/container";
-import {createDecorator as createDecoratorOriginal, NOCACHE as NOCACHEOriginal} from "./ioc/inject";
+import {
+    createDecorator as createDecoratorOriginal,
+    createResolve as createResolveOriginal,
+    createWire as createWireOriginal,
+    NOCACHE as NOCACHEOriginal,
+} from "./ioc/inject";
 
 describe("Module", () => {
     test('should export "Container" class', () => {
@@ -9,6 +14,14 @@ describe("Module", () => {
 
     test('should export "createDecorator" function', () => {
         expect(createDecorator).toBe(createDecoratorOriginal);
+    });
+
+    test('should export "createResolve" function', () => {
+        expect(createResolve).toBe(createResolveOriginal);
+    });
+
+    test('should export "createWire" function', () => {
+        expect(createWire).toBe(createWireOriginal);
     });
 
     test('should export "NOCACHE" symbol/tag', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export {Container} from "./ioc/container";
-export {createDecorator, NOCACHE} from "./ioc/inject";
+export {createDecorator, createWire, NOCACHE} from "./ioc/inject";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export {Container} from "./ioc/container";
-export {createDecorator, createWire, NOCACHE} from "./ioc/inject";
+export {createDecorator, createWire, createResolve, NOCACHE} from "./ioc/inject";

--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -119,8 +119,24 @@ class WireTest {
 }
 
 class ResolveTest {
-    cached = resolve<number>(this, TYPE.cacheTest);
-    notCached = resolve<number>(this, TYPE.cacheTest, NOCACHE);
+    cached = resolve<number>(TYPE.cacheTest);
+    notCached = resolve<number>(TYPE.cacheTest, NOCACHE);
+}
+
+function ResolveTestFunctionCached() {
+    const cached = resolve<number>(TYPE.cacheTest);
+    cached();
+    cached();
+    cached();
+    return cached();
+}
+
+function ResolveTestFunctionCacheNoCache() {
+    const cached = resolve<number>(TYPE.cacheTest, NOCACHE);
+    cached();
+    cached();
+    cached();
+    return cached();
 }
 
 container.bind<ITestClass>(TYPE.parent).to(Parent);
@@ -269,5 +285,15 @@ describe("Injector", () => {
 
         // final proof
         expect(cacheTest1.notCached()).toBe(5);
+    });
+
+    test("a function can use resolve", () => {
+        count = 0;
+        expect(ResolveTestFunctionCached()).toBe(1);
+    });
+
+    test("a function can use resolve with cache disabled", () => {
+        count = 0;
+        expect(ResolveTestFunctionCacheNoCache()).toBe(4);
     });
 });

--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -1,8 +1,9 @@
 import {Container} from "./container";
-import {createDecorator, NOCACHE} from "./inject";
+import {createDecorator, createWire, NOCACHE} from "./inject";
 
 const container = new Container();
 const inject = createDecorator(container);
+const wire = createWire(container);
 
 interface ITestClass {
     name: string;
@@ -106,6 +107,16 @@ class CacheTest {
     notCached!: number;
 }
 
+class WireTest {
+    cached!: number;
+    notCached!: number;
+
+    constructor() {
+        wire(this, "cached", TYPE.cacheTest);
+        wire(this, "notCached", TYPE.cacheTest, NOCACHE);
+    }
+}
+
 container.bind<ITestClass>(TYPE.parent).to(Parent);
 container.bind<ITestClass>(TYPE.child1).to(ChildOne);
 container.bind<ITestClass>(TYPE.child2).to(ChildTwo);
@@ -189,6 +200,34 @@ describe("Injector", () => {
         count = 0;
         const cacheTest1 = new CacheTest();
         const cacheTest2 = new CacheTest();
+        expect(cacheTest1.notCached).toBe(1);
+        expect(cacheTest1.notCached).toBe(2);
+        expect(cacheTest2.notCached).toBe(3);
+        expect(cacheTest2.notCached).toBe(4);
+
+        // final proof
+        expect(cacheTest1.notCached).toBe(5);
+    });
+
+    test("resolves new data with new instance even with cache enabled (with wire)", () => {
+        count = 0;
+        const cacheTest1 = new WireTest();
+        expect(cacheTest1.cached).toBe(1);
+        expect(cacheTest1.cached).toBe(1);
+
+        count = 9;
+        const cacheTest2 = new WireTest();
+        expect(cacheTest2.cached).toBe(10);
+        expect(cacheTest2.cached).toBe(10);
+
+        // final proof
+        expect(cacheTest1.cached).toBe(1);
+    });
+
+    test("resolves new data with new instance even with cache disabled (with wire)", () => {
+        count = 0;
+        const cacheTest1 = new WireTest();
+        const cacheTest2 = new WireTest();
         expect(cacheTest1.notCached).toBe(1);
         expect(cacheTest1.notCached).toBe(2);
         expect(cacheTest2.notCached).toBe(3);

--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -119,8 +119,8 @@ class WireTest {
 }
 
 class ResolveTest {
-    cached = resolve<number>(TYPE.cacheTest);
-    notCached = resolve<number>(TYPE.cacheTest, NOCACHE);
+    cached = resolve<number>(this, TYPE.cacheTest);
+    notCached = resolve<number>(this, TYPE.cacheTest, NOCACHE);
 }
 
 container.bind<ITestClass>(TYPE.parent).to(Parent);

--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -1,9 +1,10 @@
 import {Container} from "./container";
-import {createDecorator, createWire, NOCACHE} from "./inject";
+import {createDecorator, createResolve, createWire, NOCACHE} from "./inject";
 
 const container = new Container();
 const inject = createDecorator(container);
 const wire = createWire(container);
+const resolve = createResolve(container);
 
 interface ITestClass {
     name: string;
@@ -115,6 +116,11 @@ class WireTest {
         wire(this, "cached", TYPE.cacheTest);
         wire(this, "notCached", TYPE.cacheTest, NOCACHE);
     }
+}
+
+class ResolveTest {
+    cached = resolve<number>(TYPE.cacheTest);
+    notCached = resolve<number>(TYPE.cacheTest, NOCACHE);
 }
 
 container.bind<ITestClass>(TYPE.parent).to(Parent);
@@ -235,5 +241,33 @@ describe("Injector", () => {
 
         // final proof
         expect(cacheTest1.notCached).toBe(5);
+    });
+
+    test("resolves new data with new instance even with cache enabled (with resolve)", () => {
+        count = 0;
+        const cacheTest1 = new ResolveTest();
+        expect(cacheTest1.cached()).toBe(1);
+        expect(cacheTest1.cached()).toBe(1);
+
+        count = 9;
+        const cacheTest2 = new ResolveTest();
+        expect(cacheTest2.cached()).toBe(10);
+        expect(cacheTest2.cached()).toBe(10);
+
+        // final proof
+        expect(cacheTest1.cached()).toBe(1);
+    });
+
+    test("resolves new data with new instance even with cache disabled (with resolve)", () => {
+        count = 0;
+        const cacheTest1 = new ResolveTest();
+        const cacheTest2 = new ResolveTest();
+        expect(cacheTest1.notCached()).toBe(1);
+        expect(cacheTest1.notCached()).toBe(2);
+        expect(cacheTest2.notCached()).toBe(3);
+        expect(cacheTest2.notCached()).toBe(4);
+
+        // final proof
+        expect(cacheTest1.notCached()).toBe(5);
     });
 });

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -38,8 +38,7 @@ export function createWire(container: Container) {
 }
 
 export function createResolve(container: Container) {
-    return <T = never>(_target: any, type: symbol, ...args: symbol[]) => {
-        // `target` will get used in the Subscribable proposal. Reserving it.
+    return <T = never>(type: symbol, ...args: symbol[]) => {
         let value: T;
         return (): T => {
             if (args.indexOf(NOCACHE) !== -1 || value === undefined) {

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -38,7 +38,8 @@ export function createWire(container: Container) {
 }
 
 export function createResolve(container: Container) {
-    return <T = never>(type: symbol, ...args: symbol[]) => {
+    return function<T = never>(_target: any, type: symbol, ...args: symbol[]) {
+        // `target` will get used in the Subscribable proposal. Reserving it.
         let value: T;
         return (): T => {
             if (args.indexOf(NOCACHE) !== -1 || value === undefined) {

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -45,6 +45,6 @@ export function createResolve(container: Container) {
                 value = container.get<T>(type);
             }
             return value;
-        }
-    }
+        };
+    };
 }

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -2,27 +2,37 @@ import {Container} from "./container";
 
 export const NOCACHE = Symbol("NOCACHE");
 
+function define(target: object, property: string, container: Container, type: symbol, args: symbol[]) {
+    Object.defineProperty(target, property, {
+        get: function() {
+            const value = container.get<any>(type);
+            if (args.indexOf(NOCACHE) === -1) {
+                Object.defineProperty(this, property, {
+                    value,
+                    enumerable: true,
+                });
+            }
+            return value;
+        },
+        configurable: true,
+        enumerable: true,
+    });
+}
+
 function inject(type: symbol, container: Container, args: symbol[]) {
     return function(target: object, property: string): void {
-        Object.defineProperty(target, property, {
-            get: function() {
-                const value = container.get<any>(type);
-                if (args.indexOf(NOCACHE) === -1) {
-                    Object.defineProperty(this, property, {
-                        value,
-                        enumerable: true,
-                    });
-                }
-                return value;
-            },
-            configurable: true,
-            enumerable: true,
-        });
+        define(target, property, container, type, args);
     };
 }
 
 export function createDecorator(container: Container) {
     return function(type: symbol, ...args: symbol[]) {
         return inject(type, container, args);
+    };
+}
+
+export function createWire(container: Container) {
+    return function<T extends object>(target: T, property: keyof T & string, type: symbol, ...args: symbol[]) {
+        define(target, property, container, type, args);
     };
 }

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -36,3 +36,15 @@ export function createWire(container: Container) {
         define(target, property, container, type, args);
     };
 }
+
+export function createResolve(container: Container) {
+    return <T = never>(type: symbol, ...args: symbol[]) => {
+        let value: T;
+        return (): T => {
+            if (args.indexOf(NOCACHE) !== -1 || value === undefined) {
+                value = container.get<T>(type);
+            }
+            return value;
+        }
+    }
+}

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -20,25 +20,25 @@ function define(target: object, property: string, container: Container, type: sy
 }
 
 function inject(type: symbol, container: Container, args: symbol[]) {
-    return function(target: object, property: string): void {
+    return (target: object, property: string): void => {
         define(target, property, container, type, args);
     };
 }
 
 export function createDecorator(container: Container) {
-    return function(type: symbol, ...args: symbol[]) {
+    return (type: symbol, ...args: symbol[]) => {
         return inject(type, container, args);
     };
 }
 
 export function createWire(container: Container) {
-    return function<T extends object>(target: T, property: keyof T & string, type: symbol, ...args: symbol[]) {
+    return <T extends object>(target: T, property: keyof T & string, type: symbol, ...args: symbol[]) => {
         define(target, property, container, type, args);
     };
 }
 
 export function createResolve(container: Container) {
-    return function<T = never>(_target: any, type: symbol, ...args: symbol[]) {
+    return <T = never>(_target: any, type: symbol, ...args: symbol[]) => {
         // `target` will get used in the Subscribable proposal. Reserving it.
         let value: T;
         return (): T => {


### PR DESCRIPTION
In addition to inject dependencies with a decorator, it could be nice to have the possibility to wire up the requesting class to its dependency with a plain function.

### With decorators

```ts
class Example {
    @inject(TYPE.MyService)
    private readonly service!: IMyService;

    method() {
        this.service.doSomething();
    }
}
```

### Without decorators

The first way to wire up the dependent to the dependency will be `wire()`. I does the same like inject in the background, but without the need for decorators:

```ts
class Example {
    readonly service!: IMyService;
    constructor() {
        wire(this, "service", TYPE.MyService);
    }

    method() {
        this.service.doSomething();
    }
}
```

A 2nd way is a to resolve the dependency trough a function. This will not modify the property. Instead resolve() will assign a function which returns the dependency.

```ts
class Example {
    private readonly service = resolve<IMyService>(TYPE.MyService)

    method() {
        this.service().doSomething();
    }
}
```

With `resolve()` it is possible to resolve dependencies even in functions.

```ts
function Example() {
    const service = resolve<IMyService>(TYPE.MyService)
    service().doSomething();
}
```