### PR TITLE
Proposal: Subscribable (WIP)

### DIFF
--- a/src/ioc/inject.test.ts
+++ b/src/ioc/inject.test.ts
@@ -1,8 +1,9 @@
 import {Container} from "./container";
-import {createDecorator, NOCACHE} from "./inject";
+import {createDecorator, createWire, NOCACHE} from "./inject";
 
 const container = new Container();
 const inject = createDecorator(container);
+const wire = createWire(container);
 
 interface ITestClass {
     name: string;
@@ -106,6 +107,16 @@ class CacheTest {
     notCached!: number;
 }
 
+class WireTest {
+    cached!: number;
+    notCached!: number;
+
+    constructor() {
+        wire(this, "cached", TYPE.cacheTest);
+        wire(this, "notCached", TYPE.cacheTest, NOCACHE);
+    }
+}
+
 container.bind<ITestClass>(TYPE.parent).to(Parent);
 container.bind<ITestClass>(TYPE.child1).to(ChildOne);
 container.bind<ITestClass>(TYPE.child2).to(ChildTwo);
@@ -189,6 +200,34 @@ describe("Injector", () => {
         count = 0;
         const cacheTest1 = new CacheTest();
         const cacheTest2 = new CacheTest();
+        expect(cacheTest1.notCached).toBe(1);
+        expect(cacheTest1.notCached).toBe(2);
+        expect(cacheTest2.notCached).toBe(3);
+        expect(cacheTest2.notCached).toBe(4);
+
+        // final proof
+        expect(cacheTest1.notCached).toBe(5);
+    });
+
+    test("resolves new data with new instance even with cache enabled (with wire)", () => {
+        count = 0;
+        const cacheTest1 = new WireTest();
+        expect(cacheTest1.cached).toBe(1);
+        expect(cacheTest1.cached).toBe(1);
+
+        count = 9;
+        const cacheTest2 = new WireTest();
+        expect(cacheTest2.cached).toBe(10);
+        expect(cacheTest2.cached).toBe(10);
+
+        // final proof
+        expect(cacheTest1.cached).toBe(1);
+    });
+
+    test("resolves new data with new instance even with cache disabled (with wire)", () => {
+        count = 0;
+        const cacheTest1 = new WireTest();
+        const cacheTest2 = new WireTest();
         expect(cacheTest1.notCached).toBe(1);
         expect(cacheTest1.notCached).toBe(2);
         expect(cacheTest2.notCached).toBe(3);

--- a/src/ioc/inject.ts
+++ b/src/ioc/inject.ts
@@ -2,27 +2,37 @@ import {Container} from "./container";
 
 export const NOCACHE = Symbol("NOCACHE");
 
+function define(target: object, property: string, container: Container, type: symbol, args: symbol[]) {
+    Object.defineProperty(target, property, {
+        get: function() {
+            const value = container.get<any>(type);
+            if (args.indexOf(NOCACHE) === -1) {
+                Object.defineProperty(this, property, {
+                    value,
+                    enumerable: true,
+                });
+            }
+            return value;
+        },
+        configurable: true,
+        enumerable: true,
+    });
+}
+
 function inject(type: symbol, container: Container, args: symbol[]) {
     return function(target: object, property: string): void {
-        Object.defineProperty(target, property, {
-            get: function() {
-                const value = container.get<any>(type);
-                if (args.indexOf(NOCACHE) === -1) {
-                    Object.defineProperty(this, property, {
-                        value,
-                        enumerable: true,
-                    });
-                }
-                return value;
-            },
-            configurable: true,
-            enumerable: true,
-        });
+        define(target, property, container, type, args);
     };
 }
 
 export function createDecorator(container: Container) {
     return function(type: symbol, ...args: symbol[]) {
         return inject(type, container, args);
+    };
+}
+
+export function createWire(container: Container) {
+    return function<T extends object>(target: T, property: keyof T & string, type: symbol, ...args: symbol[]) {
+        define(target, property, container, type, args);
     };
 }


### PR DESCRIPTION
I am working with react and preact the most times, and one of the code i have to write over and over again is to subscribe to listener on `componentWillMount` or on the construction and unsubscribe on `componentWillUnmount`. 

To fix this i am thinking about to implement some kind of automatism. Just telling the inject decorator to subscribe and it will do it for me.

```ts
class Subscribable {
    listener: (() => void)[] = [];

    listen(listener: () => void): () => void {
        this.listener.push(listener);
        return () => this.listener.splice(this.listener.indexOf(listener), 1);
    }

    trigger() {
        this.listener.forEach((cb) => cb());
    }
}

class Updateable extends Component {
    @inject(TYPE.subscribable, SUBSCRIBE)
    service!: Subscribable;
}

const updateable = new Updateable();
```

Component  has the method `forceUpdate()` and can have `componentWillUnmount()`.

When we access `updateable.service` it should subscribe to `Subscribable `. When ever `trigger()` is executed `forceUpdate()` on `Updateable` should get executed.

This is work in progress.

When `Updateable` will get unmounted and its method `componentWillUnmount` gets triggered, it should unsubscribe from `Subscribable`.