### PR TITLE
Feature: Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ class Example {
 }
 ```
 
-### :new: Plugins (new in 2.0)
+## :new: Plugins (new in 2.0)
 
 Plugins are a way to hook into the dependency resolving process and execute code which can
 access the dependency and also the dependent object.
@@ -308,7 +308,9 @@ type Plugin<Dependency = any, Target = any> = (
 ) => void;
 ```
 
-For example this is a plugin which links a preact view component to a service by calling forceUpdate every time the
+### Plugin Example
+
+The following code is a plugin which links a preact view component to a service by calling forceUpdate every time the
 service executes the listener:
 
 ```ts
@@ -386,7 +388,7 @@ class Index extends Component {
 
 ```
 
-#### Prevent Plugins from Execution
+### Prevent Plugins from Execution
 
 In case you add a plugin it is executed every time the dependency is resolved. If you want to prevent this you can 
 add the `NOPLUGINS` symbol to the arguments:
@@ -400,7 +402,7 @@ class Example {
 }
 ```
 
-## Usage
+## Getting Started
 
 #### Step 1 - Installing the OWJA! IoC library
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owja/ioc",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owja/ioc",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@owja/browserslist-config": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owja/ioc",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "dependency injection for javascript",
   "main": "dist/ioc.js",
   "module": "dist/ioc.mjs",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,10 @@
-import {Container, token, createDecorator, createResolve, createWire, NOCACHE} from "./";
+import {Container, token, createDecorator, createResolve, createWire, NOCACHE, NOPLUGINS} from "./";
 import {Container as ContainerOriginal} from "./ioc/container";
 import {token as tokenOriginal} from "./ioc/token";
 import {createDecorator as createDecoratorOriginal} from "./ioc/decorator";
 import {createWire as createWireOriginal} from "./ioc/wire";
 import {createResolve as createResolveOriginal} from "./ioc/resolve";
-import {NOCACHE as NOCACHEOriginal} from "./ioc/symbol";
+import {NOCACHE as NOCACHEOriginal, NOPLUGINS as NOPLUGINSOriginal} from "./ioc/symbol";
 
 describe("Module", () => {
     test('should export "Container" class', () => {
@@ -29,5 +29,9 @@ describe("Module", () => {
 
     test('should export "NOCACHE" symbol/tag', () => {
         expect(NOCACHE).toBe(NOCACHEOriginal);
+    });
+
+    test('should export "NOPLUGINS" symbol/tag', () => {
+        expect(NOPLUGINS).toBe(NOPLUGINSOriginal);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {Container} from "./ioc/container";
+export {Container, Plugin} from "./ioc/container";
 export {createDecorator} from "./ioc/decorator";
 export {createWire} from "./ioc/wire";
 export {createResolve} from "./ioc/resolve";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ export {Container, Plugin} from "./ioc/container";
 export {createDecorator} from "./ioc/decorator";
 export {createWire} from "./ioc/wire";
 export {createResolve} from "./ioc/resolve";
-export {NOCACHE} from "./ioc/symbol";
+export {NOCACHE, NOPLUGINS} from "./ioc/symbol";
 export {token} from "./ioc/token";

--- a/src/ioc/container.plugin.test.ts
+++ b/src/ioc/container.plugin.test.ts
@@ -104,20 +104,20 @@ describe("Container 2.0", () => {
             expect(plugin.mock.calls[0][0]).toBe(resolved);
         });
 
+        test("access the arguments (5th argument)", () => {
+            expect(plugin.mock.calls[0][2].indexOf(NOCACHE)).not.toBe(-1);
+        });
+
         test("access the target (2nd argument)", () => {
             expect(plugin.mock.calls[0][1]).toBe(fakeTarget);
         });
 
         test("access the token (3th argument)", () => {
-            expect(plugin.mock.calls[0][2]).toBe(A);
+            expect(plugin.mock.calls[0][3]).toBe(A);
         });
 
         test("access the container (4th argument)", () => {
-            expect(plugin.mock.calls[0][3]).toBe(container);
-        });
-
-        test("access the arguments (5th argument)", () => {
-            expect(plugin.mock.calls[0][4].indexOf(NOCACHE)).not.toBe(-1);
+            expect(plugin.mock.calls[0][4]).toBe(container);
         });
     });
 });

--- a/src/ioc/container.plugin.test.ts
+++ b/src/ioc/container.plugin.test.ts
@@ -1,0 +1,123 @@
+import {Container, Plugin} from "./container";
+import {NOCACHE, NOPLUGINS} from "./symbol";
+import {token} from "./token";
+
+class TestClass {
+    name = "test class";
+}
+
+describe("Container 2.0", () => {
+    let container: Container;
+
+    let plugin: jest.Mock;
+
+    const A = token<TestClass>("test A");
+    const B = token<TestClass>("test B");
+
+    beforeEach(() => {
+        container = new Container();
+        plugin = jest.fn();
+    });
+
+    describe("with a plugin bound to depoendency A", () => {
+        beforeEach(() => {
+            container.bind(A).to(TestClass).withPlugin(plugin);
+            container.bind(B).to(TestClass);
+        });
+
+        test("should return property name of the test class A and B", () => {
+            expect(container.get(A).name).toBe("test class");
+            expect(container.get(B).name).toBe("test class");
+        });
+
+        test("should execute the plugin when if dependency A is requested", () => {
+            container.get(A);
+            expect(plugin).toHaveBeenCalledTimes(1);
+        });
+
+        test("should NOT execute the plugin when if dependency A is requested with NOPLUGINS symbol", () => {
+            container.get(A, [NOPLUGINS]);
+            expect(plugin).not.toBeCalled();
+        });
+
+        test("should not execute the plugin if dependency B is requested", () => {
+            container.get(B);
+            expect(plugin).not.toBeCalled();
+        });
+
+        describe("and if the plugin changes the name property of the depencency", () => {
+            beforeEach(() => {
+                const mock: Plugin<TestClass> = (cls: TestClass) => {
+                    cls.name = "this is changed";
+                };
+                plugin.mockImplementation(mock);
+            });
+
+            test("should return changed property value of dependency A", () => {
+                expect(container.get(A).name).toBe("this is changed");
+            });
+
+            test("should return default property value of dependency B", () => {
+                expect(container.get(B).name).toBe("test class");
+            });
+        });
+    });
+
+    describe("with a plugin bound to container", () => {
+        beforeEach(() => {
+            container.bind(A).to(TestClass);
+            container.bind(B).to(TestClass).inSingletonScope();
+            container.addPlugin(plugin);
+        });
+
+        test("should execute the plugin on any depencency requested", () => {
+            container.get(A);
+            expect(plugin).toHaveBeenCalledTimes(1);
+            container.get(B);
+            expect(plugin).toHaveBeenCalledTimes(2);
+        });
+
+        test("should execute plugin every time the dependency is requested, even in singleton scope", () => {
+            container.get(A);
+            container.get(A);
+            container.get(A);
+            expect(plugin).toHaveBeenCalledTimes(3);
+            container.get(B);
+            container.get(B);
+            container.get(B);
+            expect(plugin).toHaveBeenCalledTimes(6);
+        });
+    });
+
+    describe("the plugin should be able to", () => {
+        let resolved: TestClass;
+        const fakeTarget = class {};
+        const fakeArgs = [NOCACHE];
+
+        beforeEach(() => {
+            container.bind(A).to(TestClass);
+            container.addPlugin(plugin);
+            resolved = container.get(A, fakeArgs, fakeTarget);
+        });
+
+        test("access the dependency (1st argument)", () => {
+            expect(plugin.mock.calls[0][0]).toBe(resolved);
+        });
+
+        test("access the target (2nd argument)", () => {
+            expect(plugin.mock.calls[0][1]).toBe(fakeTarget);
+        });
+
+        test("access the token (3th argument)", () => {
+            expect(plugin.mock.calls[0][2]).toBe(A);
+        });
+
+        test("access the container (4th argument)", () => {
+            expect(plugin.mock.calls[0][3]).toBe(container);
+        });
+
+        test("access the arguments (5th argument)", () => {
+            expect(plugin.mock.calls[0][4].indexOf(NOCACHE)).not.toBe(-1);
+        });
+    });
+});

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -9,12 +9,12 @@ interface Item<T> {
     plugins: Plugin<T>[];
 }
 
-export type Plugin<T = unknown> = (
-    item: T,
-    target: unknown,
-    token: MaybeToken<T>,
+export type Plugin<Dependency = any, Target = any> = (
+    dependency: Dependency,
+    target: Target | undefined,
+    args: symbol[],
+    token: MaybeToken<Dependency>,
     container: Container,
-    args: MaybeToken[],
 ) => void;
 
 interface NewAble<T> {
@@ -87,7 +87,7 @@ export class Container {
         return this;
     }
 
-    get<T = never>(token: MaybeToken<T>, argTokens: MaybeToken[] = [], target?: unknown): T {
+    get<T = never>(token: MaybeToken<T>, args: symbol[] = [], target?: unknown): T {
         const item = this._registry.get(getType(token));
 
         if (item === undefined) {
@@ -97,10 +97,10 @@ export class Container {
         const {factory, value, cache, singleton, plugins} = item;
 
         const execPlugins = (item: T): T => {
-            if (argTokens.indexOf(NOPLUGINS) !== -1) return item;
+            if (args.indexOf(NOPLUGINS) !== -1) return item;
 
             for (const plugin of this._plugins.concat(plugins)) {
-                plugin(item, target, token, this, argTokens);
+                plugin(item, target, args, token, this);
             }
 
             return item;

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -11,7 +11,7 @@ export function define<T, Target extends {[key in Prop]: T}, Prop extends string
 ) {
     Object.defineProperty(target, property, {
         get: function () {
-            const value = container.get<any>(token, args, target);
+            const value = container.get<any>(token, args, this);
             if (args.indexOf(NOCACHE) === -1) {
                 Object.defineProperty(this, property, {
                     value,

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -11,7 +11,7 @@ export function define<TVal, TTarget extends {[key in TProp]: TVal}, TProp exten
 ) {
     Object.defineProperty(target, property, {
         get: function () {
-            const value = container.get<any>(token);
+            const value = container.get<any>(token, argTokens, target);
             if (argTokens.indexOf(NOCACHE) === -1) {
                 Object.defineProperty(this, property, {
                     value,

--- a/src/ioc/resolve.test.ts
+++ b/src/ioc/resolve.test.ts
@@ -101,7 +101,7 @@ describe("Resolve", () => {
 
         test("should pass the arguments", () => {
             testCls.notCached();
-            expect(plugin.mock.calls[0][4].indexOf(NOCACHE)).not.toBe(-1);
+            expect(plugin.mock.calls[0][2].indexOf(NOCACHE)).not.toBe(-1);
         });
 
         test("should pass the ResolveTest class as 2nd argument", () => {

--- a/src/ioc/resolve.ts
+++ b/src/ioc/resolve.ts
@@ -5,9 +5,9 @@ import {MaybeToken} from "./token";
 export function createResolve(container: Container) {
     return <T = never>(token: MaybeToken<T>, ...args: MaybeToken[]) => {
         let value: T;
-        return (): T => {
+        return function(this: unknown): T {
             if (args.indexOf(NOCACHE) !== -1 || value === undefined) {
-                value = container.get<T>(token);
+                value = container.get<T>(token, args, this);
             }
             return value;
         };

--- a/src/ioc/resolve.ts
+++ b/src/ioc/resolve.ts
@@ -5,7 +5,7 @@ import {MaybeToken} from "./token";
 export function createResolve(container: Container) {
     return <T = never>(token: MaybeToken<T>, ...args: MaybeToken[]) => {
         let value: T;
-        return function(this: unknown): T {
+        return function (this: unknown): T {
             if (args.indexOf(NOCACHE) !== -1 || value === undefined) {
                 value = container.get<T>(token, args, this);
             }

--- a/src/ioc/symbol.ts
+++ b/src/ioc/symbol.ts
@@ -1,1 +1,2 @@
 export const NOCACHE = Symbol("NOCACHE");
+export const NOPLUGINS = Symbol("NOPLUGINS");


### PR DESCRIPTION
This new feature for @owja/ioc Version 2 implements plugins which will get executed just before the dependency is resolved.

### The Plugin Interface

```ts
type Plugin<Dependency = any, Target = any> = (
    dependency: Dependency,
    target: Target | undefined,
    args: symbol[],
    token: MaybeToken<Dependency>,
    container: Container,
) => void;
```

#### It can directly added to a dependency after binding it

```ts
container.bind(symbol).to(class).withPlugin(plugin);
```

#### It can added to the container itself and get executed with all dependencies

```ts
container.addPlugin(plugin);
```

### ToDo
- [x] implementation
- [x] add unit tests
- [x] integration test
- [x] update documentation