### PR TITLE
(refacto) various minor improvements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export {Container, Plugin} from "./ioc/container";
+export {Container} from "./ioc/container";
+export {Plugin} from './ioc/types';
 export {createDecorator} from "./ioc/decorator";
 export {createWire} from "./ioc/wire";
 export {createResolve} from "./ioc/resolve";

--- a/src/ioc/bind.ts
+++ b/src/ioc/bind.ts
@@ -1,0 +1,23 @@
+import { Options } from "./option";
+import { PluginOptions } from "./plugin";
+import type { Item, NewAble, Factory, Value } from "./types";
+
+export class Bind<T> {
+  constructor(private _target: Item<T>) {}
+
+  to(object: NewAble<T>): Options<T> {
+      this._target.factory = () => new object();
+      return new Options<T>(this._target);
+  }
+
+  toFactory(factory: Factory<T>): Options<T> {
+      this._target.factory = factory;
+      return new Options<T>(this._target);
+  }
+
+  toValue(value: Value<T>): PluginOptions<T> {
+      if (typeof value === "undefined") throw "cannot bind a value of type undefined";
+      this._target.value = value;
+      return new PluginOptions<T>(this._target);
+  }
+}

--- a/src/ioc/container.plugin.test.ts
+++ b/src/ioc/container.plugin.test.ts
@@ -1,6 +1,7 @@
-import {Container, Plugin} from "./container";
+import {Container} from "./container";
 import {NOCACHE, NOPLUGINS} from "./symbol";
 import {token} from "./token";
+import type { Plugin } from './types';
 
 class TestClass {
     name = "test class";

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -76,9 +76,7 @@ export class Container {
         const execPlugins = (item: T): T => {
             if (args.indexOf(NOPLUGINS) !== -1) return item;
 
-            for (const plugin of this._plugins.concat(plugins)) {
-                plugin(item, target, args, token, this);
-            }
+            this._plugins.concat(plugins).forEach(plugin => plugin(item, target, args, token, this));
 
             return item;
         };

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -1,30 +1,7 @@
-import {getType, MaybeToken, stringifyToken} from "./token";
+import {getType, stringifyToken} from "./token";
 import {NOPLUGINS} from "./symbol";
+import type { Factory, Item, MaybeToken, NewAble, Plugin, Registry, Value } from "./types";
 
-interface Item<T> {
-    factory?: Factory<T>;
-    value?: Value<T>;
-    cache?: T;
-    singleton?: boolean;
-    plugins: Plugin<T>[];
-}
-
-export type Plugin<Dependency = any, Target = any> = (
-    dependency: Dependency,
-    target: Target | undefined,
-    args: symbol[],
-    token: MaybeToken<Dependency>,
-    container: Container,
-) => void;
-
-interface NewAble<T> {
-    new (...args: any[]): T;
-}
-
-type Registry = Map<symbol, Item<any>>;
-
-type Factory<T> = () => T;
-type Value<T> = T;
 
 class PluginOptions<T> {
     constructor(protected _target: Item<T>) {}

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -1,43 +1,7 @@
 import {getType, stringifyToken} from "./token";
 import {NOPLUGINS} from "./symbol";
-import type { Factory, Item, MaybeToken, NewAble, Plugin, Registry, Value } from "./types";
-
-
-class PluginOptions<T> {
-    constructor(protected _target: Item<T>) {}
-
-    withPlugin(plugin: Plugin<T>): PluginOptions<T> {
-        this._target.plugins.push(plugin);
-        return this;
-    }
-}
-
-class Options<T> extends PluginOptions<T> {
-    inSingletonScope(): PluginOptions<T> {
-        this._target.singleton = true;
-        return this;
-    }
-}
-
-class Bind<T> {
-    constructor(private _target: Item<T>) {}
-
-    to(object: NewAble<T>): Options<T> {
-        this._target.factory = () => new object();
-        return new Options<T>(this._target);
-    }
-
-    toFactory(factory: Factory<T>): Options<T> {
-        this._target.factory = factory;
-        return new Options<T>(this._target);
-    }
-
-    toValue(value: Value<T>): PluginOptions<T> {
-        if (typeof value === "undefined") throw "cannot bind a value of type undefined";
-        this._target.value = value;
-        return new PluginOptions<T>(this._target);
-    }
-}
+import type { Item, MaybeToken, Plugin, Registry } from "./types";
+import { Bind } from "./bind";
 
 export class Container {
     private _registry: Registry = new Map<symbol, Item<any>>();

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -33,9 +33,7 @@ class Bind<T> {
     }
 
     toValue(value: Value<T>): PluginOptions<T> {
-        if (typeof value === "undefined") {
-            throw "cannot bind a value of type undefined";
-        }
+        if (typeof value === "undefined") throw "cannot bind a value of type undefined";
         this._target.value = value;
         return new PluginOptions<T>(this._target);
     }
@@ -55,9 +53,7 @@ export class Container {
     }
 
     remove(token: MaybeToken): Container {
-        if (this._registry.get(getType(token)) === undefined) {
-            throw `${stringifyToken(token)} was never bound`;
-        }
+        if (this._registry.get(getType(token)) === undefined) throw `${stringifyToken(token)} was never bound`;
 
         this._registry.delete(getType(token));
 
@@ -67,9 +63,7 @@ export class Container {
     get<T = never>(token: MaybeToken<T>, args: symbol[] = [], target?: unknown): T {
         const item = this._registry.get(getType(token));
 
-        if (item === undefined) {
-            throw `nothing bound to ${stringifyToken(token)}`;
-        }
+        if (item === undefined) throw `nothing bound to ${stringifyToken(token)}`;
 
         const {factory, value, cache, singleton, plugins} = item;
 
@@ -110,9 +104,7 @@ export class Container {
     }
 
     private _create<T>(token: MaybeToken<T>): Item<T> {
-        if (this._registry.get(getType(token)) !== undefined) {
-            throw `object can only bound once: ${stringifyToken(token)}`;
-        }
+        if (this._registry.get(getType(token)) !== undefined) throw `object can only bound once: ${stringifyToken(token)}`;
 
         const item = {plugins: []};
         this._registry.set(getType(token), item);

--- a/src/ioc/decorator.ts
+++ b/src/ioc/decorator.ts
@@ -1,6 +1,6 @@
 import {Container} from "./container";
 import {define} from "./define";
-import {MaybeToken} from "./token";
+import type {MaybeToken} from "./types";
 
 export function createDecorator(container: Container) {
     return <T>(token: MaybeToken<T>, ...args: symbol[]) => {

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -1,6 +1,6 @@
 import {Container} from "./container";
 import {NOCACHE} from "./symbol";
-import {MaybeToken} from "./token";
+import type {MaybeToken} from "./types";
 
 export function define<T, Target extends {[key in Prop]: T}, Prop extends string>(
     target: Target,

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -12,12 +12,11 @@ export function define<T, Target extends {[key in Prop]: T}, Prop extends string
     Object.defineProperty(target, property, {
         get: function () {
             const value = container.get<any>(token, args, this);
-            if (args.indexOf(NOCACHE) === -1) {
+            if (args.indexOf(NOCACHE) === -1)
                 Object.defineProperty(this, property, {
                     value,
                     enumerable: true,
                 });
-            }
             return value;
         },
         configurable: true,

--- a/src/ioc/option.ts
+++ b/src/ioc/option.ts
@@ -1,0 +1,8 @@
+import { PluginOptions } from "./plugin";
+
+export class Options<T> extends PluginOptions<T> {
+  inSingletonScope(): PluginOptions<T> {
+      this._target.singleton = true;
+      return this;
+  }
+}

--- a/src/ioc/plugin.ts
+++ b/src/ioc/plugin.ts
@@ -1,0 +1,10 @@
+import type { Item, Plugin } from "./types";
+
+export class PluginOptions<T> {
+  constructor(protected _target: Item<T>) {}
+
+  withPlugin(plugin: Plugin<T>): PluginOptions<T> {
+      this._target.plugins.push(plugin);
+      return this;
+  }
+}

--- a/src/ioc/resolve.ts
+++ b/src/ioc/resolve.ts
@@ -1,6 +1,6 @@
 import {Container} from "./container";
 import {NOCACHE} from "./symbol";
-import {MaybeToken} from "./token";
+import type {MaybeToken} from "./types";
 
 export function createResolve(container: Container) {
     return <T = never>(token: MaybeToken<T>, ...args: symbol[]) => {

--- a/src/ioc/token.ts
+++ b/src/ioc/token.ts
@@ -1,15 +1,8 @@
+import type { MaybeToken, Token } from "./types";
+
 export function token<T>(name: string) {
     return {type: Symbol(name)} as Token<T>;
 }
-
-declare const typeMarker: unique symbol;
-
-export interface Token<T> {
-    type: symbol;
-    [typeMarker]: T;
-}
-
-export type MaybeToken<T = unknown> = Token<T> | symbol;
 
 function isToken<T>(token: MaybeToken<T>): token is Token<T> {
     return typeof token != "symbol";

--- a/src/ioc/token.ts
+++ b/src/ioc/token.ts
@@ -9,17 +9,13 @@ function isToken<T>(token: MaybeToken<T>): token is Token<T> {
 }
 
 export function stringifyToken(token: MaybeToken): string {
-    if (isToken(token)) {
-        return `Token(${token.type.toString()})`;
-    } else {
-        return token.toString();
-    }
+    return isToken(token)
+        ? `Token(${token.type.toString()})`
+        : token.toString();
 }
 
 export function getType(token: MaybeToken): symbol {
-    if (isToken(token)) {
-        return token.type;
-    } else {
-        return token;
-    }
+    return isToken(token)
+        ? token.type
+        : token;
 }

--- a/src/ioc/token.ts
+++ b/src/ioc/token.ts
@@ -1,21 +1,15 @@
 import type { MaybeToken, Token } from "./types";
 
-export function token<T>(name: string) {
-    return {type: Symbol(name)} as Token<T>;
-}
+export const token = <T>(name: string) => ({type: Symbol(name)} as Token<T>)
 
-function isToken<T>(token: MaybeToken<T>): token is Token<T> {
-    return typeof token != "symbol";
-}
+const isToken = <T>(token: MaybeToken<T>): token is Token<T> => typeof token != "symbol";
 
-export function stringifyToken(token: MaybeToken): string {
-    return isToken(token)
+export const stringifyToken = (token: MaybeToken): string =>
+    isToken(token)
         ? `Token(${token.type.toString()})`
         : token.toString();
-}
 
-export function getType(token: MaybeToken): symbol {
-    return isToken(token)
+export const getType = (token: MaybeToken): symbol =>
+    isToken(token)
         ? token.type
         : token;
-}

--- a/src/ioc/types.ts
+++ b/src/ioc/types.ts
@@ -1,0 +1,36 @@
+import type { Container } from "./container";
+
+// container
+export interface Item<T> {
+  factory?: Factory<T>;
+  value?: Value<T>;
+  cache?: T;
+  singleton?: boolean;
+  plugins: Plugin<T>[];
+}
+
+export type Plugin<Dependency = any, Target = any> = (
+  dependency: Dependency,
+  target: Target | undefined,
+  args: symbol[],
+  token: MaybeToken<Dependency>,
+  container: Container,
+) => void;
+
+export interface NewAble<T> {
+  new (...args: any[]): T;
+}
+
+export type Registry = Map<symbol, Item<any>>;
+
+export type Factory<T> = () => T;
+export type Value<T> = T;
+
+// tokens
+export type MaybeToken<T = unknown> = Token<T> | symbol;
+
+declare const typeMarker: unique symbol;
+export interface Token<T> {
+  type: symbol;
+  [typeMarker]: T;
+}

--- a/src/ioc/wire.ts
+++ b/src/ioc/wire.ts
@@ -1,6 +1,6 @@
 import {Container} from "./container";
 import {define} from "./define";
-import {MaybeToken} from "./token";
+import type {MaybeToken} from "./types";
 
 export function createWire(container: Container) {
     return <Value, Target extends {[key in Prop]: Value}, Prop extends string>(


### PR DESCRIPTION
In this PR I:
- simply moved the types in their own file and broke down every classes in their individual file
- changed a for loop to a forEach => reduces build size
- use ternary and arrowFunctions in `token.ts` => reduces build size

previous build size
```
Build "@owja/ioc" to dist:
        923 B: ioc.js.gz
        798 B: ioc.js.br
        922 B: ioc.mjs.gz
        806 B: ioc.mjs.br
```

new
```
Build "@owja/ioc" to dist:
        911 B: ioc.js.gz
        793 B: ioc.js.br
        913 B: ioc.mjs.gz
        804 B: ioc.mjs.br
```

--------

If you agree to enforce TypeSafety by removing the `MaybeToken` type and its logic it can be easily brought down to 
```
Build "@owja/ioc" to dist:
        873 B: ioc.js.gz
        756 B: ioc.js.br
        882 B: ioc.mjs.gz
        780 B: ioc.mjs.br
```