### PR TITLE
(feat) restaure backwards compatibility with previous syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library implements dependency injection for javascript and typescript.
 * Similar syntax to InversifyJS
 * Can be used without decorators
 * Less Features but **straight forward**
-* Can bind dependencies as **classes**, **factories** and **static values**
+* Can bind dependencies as **classes**, **factories** and **static values** and provide dependencie arguments or parameters if needed
 * Supports binding in **singleton scope**
 * **Cached** - Resolves only once in each dependent class by default
 * **Cache can switched off** directly at the inject decorator
@@ -50,7 +50,8 @@ const container = new Container();
 #### Binding a class
 
 This is the default way to bind a dependency. The class will get instantiated when the
-dependency gets resolved.
+dependency gets resolved. You will be able to pass down it's dependencie arguments once you resolve it.
+
 
 ```ts
 container.bind<ServiceInterface>(symbol).to(Service);
@@ -71,6 +72,7 @@ Factories are functions which will get called when the dependency gets resolved
 ```ts
 container.bind<ServiceInterface>(symbol).toFactory(() => new Service());
 container.bind<string>(symbol).toFactory(() => "just a string");
+container.bind<string>(symbol).toFactory((a: string) => `I need a string parameter: ${a}`);
 ```
 
 A factory can configured for singleton scope too. This way will only executed once.
@@ -153,7 +155,7 @@ Then we can use the decorator to inject the dependency.
 
 ```ts
 class Example {
-    @inject(symbol)
+    @inject(symbol/*, [tags], ...dependencie arguments*/)
     readonly service!: Interface;
     
     method() {
@@ -179,7 +181,7 @@ class Example {
     readonly service!: Interface;
     
     constructor() {
-        wire(this, "service", symbol);
+        wire(this, "service", symbol/*, [tags], ...dependencie arguments*/);
     }
     
     method() {
@@ -207,7 +209,7 @@ class Example {
     private readonly service = resolve<Interface>(symbol);
     
     method() {
-        this.service().doSomething();
+        this.service(/*...dependencie arguments*/).doSomething();
     }
 }
 ```
@@ -215,7 +217,7 @@ class Example {
 ```ts
 function Example() {
     const service = resolve<Interface>(symbol);
-    service().doSomething();
+    service(/*...dependencie arguments*/).doSomething();
 }
 ```
 
@@ -267,7 +269,7 @@ but it throws a type error if the types don't match:
 
 ```ts
 class Example {
-    @inject(TYPE.Service) // throws a type error because WrongInterface is not compatible with MyServiceInterface
+    @inject(TYPE.Service/*, [tags], ...dependencie arguments*/) // throws a type error because WrongInterface is not compatible with MyServiceInterface
     readonly service!: WrongInterface;
 }
 ```
@@ -276,7 +278,7 @@ Correkt:
 
 ```ts
 class Example {
-    @inject(TYPE.Service)
+    @inject(TYPE.Service/*, [tags], ...dependencie arguments*/)
     readonly service!: MyServiceInterface;
 }
 ```
@@ -361,7 +363,7 @@ In a component it is then executed when the dependency is resolved:
 
 ```ts
 class Index extends Component {
-    @inject(TYPE.TranslationService, [SUBSCRIBE])
+    @inject(TYPE.TranslationService, [SUBSCRIBE]/*, ...dependencie arguments*/)
     readonly service!: TranslatorInterface;
 
     render() {
@@ -380,14 +382,14 @@ class Index extends Component {
 
     constructor() {
         super();
-        wire(this, "service", TYPE.TranslationService, [SUBSCRIBE]);
+        wire(this, "service", TYPE.TranslationService, [SUBSCRIBE]/*, ...dependencie arguments*/);
     }
     
     [...]
 }
 
 class Index extends Component {
-    readonly service = resolve(TYPE.TranslationService, [SUBSCRIBE]);
+    readonly service = resolve(TYPE.TranslationService, [SUBSCRIBE]/*, ...dependencie arguments*/);
     
     [...]
 }
@@ -403,7 +405,7 @@ add the `NOPLUGINS` tag to the arguments:
 import {NOPLUGINS} from "@owja/ioc";
 
 class Example {
-    @inject(TYPE.MyService, [NOPLUGINS])
+    @inject(TYPE.MyService, [NOPLUGINS]/*, ...dependencie arguments*/)
     readonly service!: MyServiceInterface;
 }
 ```
@@ -483,10 +485,10 @@ import {MyServiceInterface} from "./service/my-service";
 import {MyOtherServiceInterface} from "./service/my-other-service";
 
 class Example {
-    @inject(TYPE.MyService)
+    @inject(TYPE.MyService/*, [tags], ...dependencie arguments*/)
     readonly myService!: MyServiceInterface;
 
-    @inject(TYPE.MyOtherService)
+    @inject(TYPE.MyOtherService/*, [tags], ...dependencie arguments*/)
     readonly myOtherService!: MyOtherServiceInterface;
 }
 
@@ -510,7 +512,7 @@ import {NOCACHE} from "@owja/ioc";
 class Example {
     // [...]
     
-    @inject(TYPE.MyOtherSerice, NOCACHE)
+    @inject(TYPE.MyOtherSerice, NOCACHE/*, ...dependencie arguments*/)
     readonly myOtherService!: MyOtherServiceInterface;
 }
 

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -2,6 +2,7 @@ import type {Factory, Injected, Item, Token, MaybeToken, Plugin} from "./types";
 import {Bind} from "./bind";
 import {getType, stringifyToken} from "./token";
 import {NOPLUGINS} from "./tags";
+import {valueOrArrayToArray} from "./utils";
 
 const isFactory = <T>(i: Injected<T>): i is Factory<T> => typeof i === "function";
 
@@ -42,7 +43,7 @@ export class Container {
                 : (item.cache = item.cache || item.injected())
             : item.injected;
 
-        if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOPLUGINS) === -1)
+        if (valueOrArrayToArray(tags).indexOf(NOPLUGINS) === -1)
             item.plugins.concat(this._plugins).forEach((plugin) => {
                 plugin(value, target, tags, token, this);
             });

--- a/src/ioc/container.ts
+++ b/src/ioc/container.ts
@@ -28,7 +28,7 @@ export class Container {
 
     get<T, U extends Array<unknown> = never>(
         token: Token<T, U> | MaybeToken<T>,
-        tags: symbol[] = [],
+        tags: symbol[] | symbol = [],
         target?: unknown,
         injectedArgs: Array<unknown> = [],
     ): T {
@@ -42,7 +42,7 @@ export class Container {
                 : (item.cache = item.cache || item.injected())
             : item.injected;
 
-        if (tags.indexOf(NOPLUGINS) === -1)
+        if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOPLUGINS) === -1)
             item.plugins.concat(this._plugins).forEach((plugin) => {
                 plugin(value, target, tags, token, this);
             });

--- a/src/ioc/createDecorator.test.ts
+++ b/src/ioc/createDecorator.test.ts
@@ -142,7 +142,7 @@ class factoryWithArguments {
     @inject<string, Parameters<typeof factoryOneArg>>(TYPE.factoryOneArg, [], "hello")
     factOne!: string;
 
-    @inject<string, Parameters<typeof factoryTwoArg>>(TYPE.factoryTwoArgs, [], "hello", "world")
+    @inject<string, Parameters<typeof factoryTwoArg>>(TYPE.factoryTwoArgs, NOCACHE, "hello", "world")
     factTwo!: string;
 }
 

--- a/src/ioc/createDecorator.ts
+++ b/src/ioc/createDecorator.ts
@@ -5,7 +5,7 @@ import {define} from "./define";
 export function createDecorator(container: Container) {
     return <T, K extends Array<unknown>>(
         token: Token<T, K> | MaybeToken<T>,
-        tags: symbol[] = [],
+        tags: symbol[] | symbol = [],
         ...injectedArgs: K
     ) => {
         return function <Target extends {[key in Prop]: T}, Prop extends keyof Target>(

--- a/src/ioc/createResolve.test.ts
+++ b/src/ioc/createResolve.test.ts
@@ -15,7 +15,7 @@ const resolve = createResolve(container);
 class ResolveTest {
     cached = resolve(TYPE.cacheTest);
     notCached = resolve(TYPE.cacheTest, [NOCACHE]);
-    noPlugins = resolve(TYPE.cacheTest, [NOPLUGINS]);
+    noPlugins = resolve(TYPE.cacheTest, NOPLUGINS);
 }
 
 let count: number;

--- a/src/ioc/createResolve.ts
+++ b/src/ioc/createResolve.ts
@@ -1,12 +1,13 @@
 import type {Token, MaybeToken} from "./types";
 import type {Container} from "./container";
 import {NOCACHE} from "./tags";
+import {valueOrArrayToArray} from "./utils";
 
 export function createResolve(container: Container) {
     return <T, U extends Array<unknown>>(token: Token<T, U> | MaybeToken<T>, tags: symbol[] | symbol = []) => {
         let value: T;
         return function <R>(this: R, ...injectedArgs: U): T {
-            if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOCACHE) !== -1 || value === undefined) {
+            if (valueOrArrayToArray(tags).indexOf(NOCACHE) !== -1 || value === undefined) {
                 value = container.get(token, tags, this, injectedArgs);
             }
             return value;

--- a/src/ioc/createResolve.ts
+++ b/src/ioc/createResolve.ts
@@ -3,10 +3,10 @@ import type {Container} from "./container";
 import {NOCACHE} from "./tags";
 
 export function createResolve(container: Container) {
-    return <T, U extends Array<unknown>>(token: Token<T, U> | MaybeToken<T>, tags: symbol[] = []) => {
+    return <T, U extends Array<unknown>>(token: Token<T, U> | MaybeToken<T>, tags: symbol[] | symbol = []) => {
         let value: T;
         return function <R>(this: R, ...injectedArgs: U): T {
-            if (tags.indexOf(NOCACHE) !== -1 || value === undefined) {
+            if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOCACHE) !== -1 || value === undefined) {
                 value = container.get(token, tags, this, injectedArgs);
             }
             return value;

--- a/src/ioc/createWire.ts
+++ b/src/ioc/createWire.ts
@@ -7,7 +7,7 @@ export function createWire(container: Container) {
         target: Target,
         property: Prop,
         token: Token<Value, K> | MaybeToken<Value>,
-        tags: symbol[] = [],
+        tags: symbol[] | symbol = [],
         ...injectedArgs: K
     ) => {
         define(target, property, container, token, tags, ...injectedArgs);

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -7,13 +7,13 @@ export function define<T, Target extends {[key in Prop]: T}, Prop extends keyof 
     property: Prop,
     container: Container,
     token: Token<T, K> | MaybeToken<T>,
-    tags: symbol[],
+    tags: symbol[] | symbol,
     ...injectedArgs: K
 ) {
     Object.defineProperty(target, property, {
         get: function <R>(this: R): T {
             const value = container.get(token, tags, this, injectedArgs);
-            if (tags.indexOf(NOCACHE) === -1)
+            if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOCACHE) === -1)
                 Object.defineProperty(this, property, {
                     value,
                     enumerable: true,

--- a/src/ioc/define.ts
+++ b/src/ioc/define.ts
@@ -1,6 +1,7 @@
 import type {Token, MaybeToken} from "./types";
 import {Container} from "./container";
 import {NOCACHE} from "./tags";
+import {valueOrArrayToArray} from "./utils";
 
 export function define<T, Target extends {[key in Prop]: T}, Prop extends keyof Target, K extends Array<unknown>>(
     target: Target,
@@ -13,7 +14,7 @@ export function define<T, Target extends {[key in Prop]: T}, Prop extends keyof 
     Object.defineProperty(target, property, {
         get: function <R>(this: R): T {
             const value = container.get(token, tags, this, injectedArgs);
-            if ((typeof tags === "symbol" ? [tags] : tags).indexOf(NOCACHE) === -1)
+            if (valueOrArrayToArray(tags).indexOf(NOCACHE) === -1)
                 Object.defineProperty(this, property, {
                     value,
                     enumerable: true,

--- a/src/ioc/token.ts
+++ b/src/ioc/token.ts
@@ -1,11 +1,9 @@
 import type {MaybeToken, Token} from "./types";
+import {isSymbol} from "./utils";
 
 export const token = <T, U extends Array<unknown> = unknown[]>(name: string) => ({type: Symbol(name)} as Token<T, U>);
 
-const isToken = <T, U extends Array<unknown>>(token: MaybeToken<T, U>): token is Token<T, U> =>
-    typeof token != "symbol";
-
 export const stringifyToken = (token: MaybeToken): string =>
-    isToken(token) ? `Token(${token.type.toString()})` : token.toString();
+    !isSymbol(token) ? `Token(${token.type.toString()})` : token.toString();
 
-export const getType = (token: MaybeToken): symbol => (isToken(token) ? token.type : token);
+export const getType = (token: MaybeToken): symbol => (!isSymbol(token) ? token.type : token);

--- a/src/ioc/types.ts
+++ b/src/ioc/types.ts
@@ -12,7 +12,7 @@ export interface Item<T> {
 export type Plugin<Dependency = unknown> = (
     dependency: Dependency,
     target: unknown,
-    tags: symbol[],
+    tags: symbol[] | symbol,
     token: MaybeToken<Dependency>,
     container: Container,
 ) => void;

--- a/src/ioc/utils.ts
+++ b/src/ioc/utils.ts
@@ -1,0 +1,3 @@
+export const isSymbol = (t: unknown): t is symbol => typeof t == "symbol";
+
+export const valueOrArrayToArray = (smt: symbol[] | symbol): symbol[] => (isSymbol(smt) ? [smt] : smt);


### PR DESCRIPTION
with these commits the backwards compatibility is restaured (only one tag with old syntax)
```
Build "@owja/ioc" to dist:
        928 B: ioc.js.gz    (+ 8 B | +0.87%)
        791 B: ioc.js.br    (+ 5 B | +0.64%)
        933 B: ioc.mjs.gz   (+ 5 B | +0.54%)
        808 B: ioc.mjs.br   (+ 4 B | +0.50%)
```

The new `utils.ts` is here to reduce as much as possible the build size, without it I was at : 
```
Build "@owja/ioc" to dist:
        941 B: ioc.js.gz    (+21 B | +2.28%)
        809 B: ioc.js.br    (+23 B | +2.93%)
        951 B: ioc.mjs.gz   (+23 B | +2.48%)
        832 B: ioc.mjs.br   (+28 B | +3.48%)
```