### PR TITLE
fix: `toValue` can't take a function as input

### DIFF
--- a/src/ioc/bind.ts
+++ b/src/ioc/bind.ts
@@ -16,7 +16,8 @@ export class Bind<T, U extends Array<unknown>> {
     }
 
     toValue(value: Value<T>): PluginOptions<T> {
-        if (typeof value === "undefined" || typeof value === "function") throw "Cannot bind a value of type undefined or function";
+        if (typeof value === "undefined" || typeof value === "function")
+            throw "Cannot bind a value of type undefined or function";
         this._target.injected = value;
         return new PluginOptions<T>(this._target);
     }

--- a/src/ioc/bind.ts
+++ b/src/ioc/bind.ts
@@ -16,7 +16,7 @@ export class Bind<T, U extends Array<unknown>> {
     }
 
     toValue(value: Value<T>): PluginOptions<T> {
-        if (typeof value === "undefined") throw "cannot bind a value of type undefined";
+        if (typeof value === "undefined" || typeof value === "function") throw "Cannot bind a value of type undefined or function";
         this._target.injected = value;
         return new PluginOptions<T>(this._target);
     }

--- a/src/ioc/container.test.ts
+++ b/src/ioc/container.test.ts
@@ -147,7 +147,13 @@ describe("Container using symbols", () => {
 
     test("can not bind a constant value of undefined", () => {
         expect(() => container.bind<undefined>(exampleSymbol).toValue(undefined)).toThrow(
-            "cannot bind a value of type undefined",
+            "Cannot bind a value of type undefined or function",
+        );
+    });
+
+    test("can not bind a function with `toValue`", () => {
+        expect(() => container.bind<() => number>(exampleSymbol).toValue(() => 2)).toThrow(
+            "Cannot bind a value of type undefined or function",
         );
     });
 


### PR DESCRIPTION
This makes `.toValue` throw an error if called with a function.
It kinda fixes #63.

Better documentation would be nice too, I'll look into it when I find time.

I'm also wondering if those checks can be achieved with TS only (getting `never` type if we provide a wrong input).
This would be safer, kinda self-documenting (if we wrap `never`) and would reduce build size.

---
New Build size
```
Build "@owja/ioc" to dist:
        942 B: ioc.js.gz        (+ 9 B)
        805 B: ioc.js.br        (+11 B)
        948 B: ioc.mjs.gz       (+10 B)
        826 B: ioc.mjs.br       (+ 9 B)
```